### PR TITLE
added ros2_usb_camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - [joystick_ros2](https://github.com/FurqanHabibi/joystick_ros2) - Joystick driver for ROS2, support all platforms: Linux, macOS, Windows ![joystick_ros2](https://img.shields.io/github/stars/FurqanHabibi/joystick_ros2.svg).
 - [ros2_teleop_keyboard](https://github.com/rohbotics/ros2_teleop_keyboard) - Teleop Twist Keyboard for ROS2 ![ros2_teleop_keyboard](https://img.shields.io/github/stars/rohbotics/ros2_teleop_keyboard.svg).
 - [ros_astra_camera](https://github.com/ros2/ros_astra_camera) - ROS2 wrapper for Astra camera ![ros_astra_camera](https://img.shields.io/github/stars/ros2/ros_astra_camera.svg).
+- [ros2_usb_camera](https://github.com/klintan/ros2_usb_camera) - ROS2 General USB camera driver ![ros_astra_camera](https://img.shields.io/github/stars/klintan/ros2_usb_camera.svg).
 - [ros2_android_drivers](https://github.com/esteve/ros2_android_drivers) - Collection of ROS2 drivers for several Android sensors ![ros2_android_drivers](https://img.shields.io/github/stars/esteve/ros2_android_drivers.svg).
 - [ros2_intel_realsense](https://github.com/intel/ros2_intel_realsense) - ROS2 Wrapper for Intel® RealSense™ Devices ![ros2_intel_realsense](https://img.shields.io/github/stars/intel/ros2_intel_realsense.svg).
 - [raspicam2_node](https://github.com/christianrauch/raspicam2_node) - ROS2 node for camera module of Raspberry Pi ![raspicam2_node](https://img.shields.io/github/stars/christianrauch/raspicam2_node.svg).


### PR DESCRIPTION
Trying to make a more general USB camera node for Ros2, fairly simple still, but supports camera_info and loading calibration yaml setting files. Built using opencv so should support a wider range of cameras. Def need some more work, but its a start. Feel free to add if you feel its contributing.