### PR TITLE
add cli cheats sheet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
   - [Bouncy package status](http://repo.ros2.org/status_page/ros_bouncy_default.html) - Status of ROS Bouncy packages.
   - [Ardent package status](http://repo.ros2.org/status_page/ros_ardent_default.html) - Status of ROS2 Ardent packages.
 - [ROS2 Buildfarm](http://build.ros2.org) - Build information (Jenkins build farm).
+- [ROS2 CLI cheats sheet](https://github.com/artivis/ros2_cheats_sheet/blob/master/cli/cli_cheats_sheet.pdf) - A cheats sheet for ROS 2 Command Line Interface.
 
 ## Community
 


### PR DESCRIPTION
Add a link to a ROS 2 Command Line Interface (CLI) cheats sheet.