### PR TITLE
Added ROS2 Foxy packages and darknet_ros link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - [ros2_pytorch](https://github.com/klintan/ros2_pytorch) - ROS2 nodes for computer vision tasks in PyTorch ![ros2_pytorch](https://img.shields.io/github/stars/klintan/ros2_pytorch.svg).
 - [pid](https://github.com/UTNuclearRoboticsPublic/pid) - A PID controller for ROS2. ![pid](https://img.shields.io/github/stars/UTNuclearRoboticsPublic/pid.svg)
 - [system-modes](https://github.com/micro-ROS/system_modes) - System modes for ROS 2 and micro-ROS.
+- [darknet_ros](https://github.com/leggedrobotics/darknet_ros/tree/ros2) - ROS2 wrapper for deploying Darknet's YOLO Computer Vision model.
 
 ### Middleware
 

--- a/readme.md
+++ b/readme.md
@@ -238,6 +238,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 ## Documentation
 
 - [ROS Index](https://index.ros.org/) - Future single entry point into ROS2 documentation (BETA).
+  - [Foxy packages](https://index.ros.org/packages/page/1/time/#foxy).
   - [Dashing packages](https://index.ros.org/packages/page/1/time/#dashing).
   - [Crystal packages](https://index.ros.org/packages/page/1/time/#crystal).
   - [Bouncy packages](https://index.ros.org/packages/page/1/time/#bouncy).
@@ -326,7 +327,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - Node.js Client & Web Bridge Ready for ROS 2.0
 - RCLAda: the Ada client library for ROS2
 
-### Embedded World Conference 2018 
+### Embedded World Conference 2018
 
 - ADLink Neuron: An industrial oriented ROS2-based platform [Slides](https://raw.githubusercontent.com/Adlink-ROS/adlink_neuronbot/master/document/ADLINK_NeuronBot_20180313.pdf) [Video](https://www.youtube.com/watch?v=RC6XvTvTs9Y&feature=youtu.be) [Video](https://www.youtube.com/watch?v=qA4_Hmnd_tM&feature=youtu.be)
 


### PR DESCRIPTION
Hi @fkromer, thank you for compiling this comprehensive list of ROS2 resources so that it is more accessible to ROS2 users. 

This pull request is **only to add two links**, as follows:
1. [Foxy packages](https://index.ros.org/packages/page/1/time/#foxy)
2. [darknet_ros](https://github.com/leggedrobotics/darknet_ros/tree/ros2)

The reason for adding these 2 links is as follows:
1. This is to update the documentation link to the most recent Foxy Fitzroy.
2. This is to include an actively-developed and popular Computer-Vision-enabling ROS2 package. 

Hopefully these additions can help improve ROS2 documentation to ROS2 developers as well as have them be aware of more useful ROS2 packages.