### PR TITLE
Adding ros-industrial EPD and EMD under Application Layer.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,8 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - [pid](https://github.com/UTNuclearRoboticsPublic/pid) - A PID controller for ROS2. ![pid](https://img.shields.io/github/stars/UTNuclearRoboticsPublic/pid.svg)
 - [system-modes](https://github.com/micro-ROS/system_modes) - System modes for ROS 2 and micro-ROS.
 - [darknet_ros](https://github.com/leggedrobotics/darknet_ros/tree/ros2) - ROS2 wrapper for deploying Darknet's YOLO Computer Vision model.
+- [easy_perception_deployment](https://github.com/ros-industrial/easy_perception_deployment) - Package that accelerates training and deployment of Computer Vision models for industries. ![easy_perception_deployment](https://img.shields.io/github/stars/ros-industrial/easy_perception_deployment.svg)
+- [easy_manipulation_deployment](https://github.com/ros-industrial/easy_manipulation_deployment) - Package that integrates perception elements to establish an end-to-end pick and place task. ![easy_manipulation_deployment](https://img.shields.io/github/stars/ros-industrial/easy_manipulation_deployment.svg)
 
 ### Middleware
 


### PR DESCRIPTION
This pull request adds links to two repositories under **ros-industrial**, [easy_perception_deployment](https://github.com/ros-industrial/easy_perception_deployment) and [easy_manipulation_deployment](https://github.com/ros-industrial/easy_manipulation_deployment).

These repositories have been verified to be recently updated (as of 5th June 2021) and adhering to [REP-2004](https://github.com/ros-infrastructure/rep/pull/218) code quality standards.