### PR TITLE
Added info about Husarnet - a VPN for ROS & ROS 2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - [ros2_java_docker](https://github.com/esteve/ros2_java_docker) - Dockerfiles for building ros2_java with OpenJDK and Android. ![ros2_java_docker](https://img.shields.io/github/stars/esteve/ros2_java_docker.svg)
 - [micro-ROS/docker](https://github.com/micro-ROS/docker) - Docker-related material to setup, configure and develop with micro-ROS hardware.
 - [ros-tooling/cross_compile](https://github.com/ros-tooling/cross_compile) - Cross compile ROS and ROS 2 workspaces to non-native architectures and generate corresponding Docker images.
-- [Connecting ROS 2 nodes over the internet](https://husarnet.com/blog/ros2-docker)
+- [ros2-docker](https://husarnet.com/blog/ros2-docker) - Connecting ROS 2 nodes running in Docker containers over the internet
 
 ### Networking
 

--- a/readme.md
+++ b/readme.md
@@ -54,8 +54,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 
 ### Networking
 
-- [Husarnet VPN](https://github.com/husarnet/husarnet)- A P2P, secure network layer dedicated for ROS & ROS 2.
-[husarnet](https://img.shields.io/github/stars/husarnet/husarnet.svg)
+- [Husarnet VPN](https://github.com/husarnet/husarnet)- A P2P, secure network layer dedicated for ROS & ROS 2. ![husarnet](https://img.shields.io/github/stars/husarnet/husarnet.svg)
 
 ### Ecosystem
 

--- a/readme.md
+++ b/readme.md
@@ -50,11 +50,11 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - [ros2_java_docker](https://github.com/esteve/ros2_java_docker) - Dockerfiles for building ros2_java with OpenJDK and Android. ![ros2_java_docker](https://img.shields.io/github/stars/esteve/ros2_java_docker.svg)
 - [micro-ROS/docker](https://github.com/micro-ROS/docker) - Docker-related material to setup, configure and develop with micro-ROS hardware.
 - [ros-tooling/cross_compile](https://github.com/ros-tooling/cross_compile) - Cross compile ROS and ROS 2 workspaces to non-native architectures and generate corresponding Docker images.
-- [ros2-docker](https://husarnet.com/blog/ros2-docker) - Connecting ROS 2 nodes running in Docker containers over the internet
+- [ros2-docker](https://husarnet.com/blog/ros2-docker) - Connecting ROS 2 nodes running in Docker containers over the internet.
 
 ### Networking
 
-- [Husarnet VPN](https://github.com/husarnet/husarnet) - A P2P, secure network layer dedicated for ROS & ROS 2
+- [Husarnet VPN](https://github.com/husarnet/husarnet) [![GitHub stars](https://img.shields.io/github/stars/husarnet/husarnet?style=social)](https://github.com/husarnet/husarnet/stargazers/) - A P2P, secure network layer dedicated for ROS & ROS 2.
 
 ### Ecosystem
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,8 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 
 ### Networking
 
-- [Husarnet VPN](https://github.com/husarnet/husarnet) [![GitHub stars](https://img.shields.io/github/stars/husarnet/husarnet?style=social)](https://github.com/husarnet/husarnet/stargazers/) - A P2P, secure network layer dedicated for ROS & ROS 2.
+- [Husarnet VPN](https://github.com/husarnet/husarnet)- A P2P, secure network layer dedicated for ROS & ROS 2.
+[husarnet](https://img.shields.io/github/stars/husarnet/husarnet.svg)
 
 ### Ecosystem
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,11 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 - [ros2_java_docker](https://github.com/esteve/ros2_java_docker) - Dockerfiles for building ros2_java with OpenJDK and Android. ![ros2_java_docker](https://img.shields.io/github/stars/esteve/ros2_java_docker.svg)
 - [micro-ROS/docker](https://github.com/micro-ROS/docker) - Docker-related material to setup, configure and develop with micro-ROS hardware.
 - [ros-tooling/cross_compile](https://github.com/ros-tooling/cross_compile) - Cross compile ROS and ROS 2 workspaces to non-native architectures and generate corresponding Docker images.
+- [Connecting ROS 2 nodes over the internet](https://husarnet.com/blog/ros2-docker)
+
+### Networking
+
+- [Husarnet VPN](https://github.com/husarnet/husarnet) - A P2P, secure network layer dedicated for ROS & ROS 2
 
 ### Ecosystem
 
@@ -422,6 +427,7 @@ DDS Security.
 - [FARobot](https://www.farobottech.com/) - Swarm Robot System, a ROS 2/DDS based Fleet Management System.
 - [Fraunhofer Institute for Manufacturing Engineering and Automation IPA](https://www.ipa.fraunhofer.de/en/expertise/robot-and-assistive-systems.html) - Robot and assistive systems.
 - [GESTALT ROBOTICS](https://www.gestalt-robotics.com/en/home) - Service provider for intelligent automation.
+- [Husarnet](https://husarnet.com) - Open Source, P2P, low-latency VPN dedicated for robots.
 - [iRobot](https://www.irobot.de/) - Manufacturer of vacuuming and mopping robots.
 - [Klepsydra Technologies](https://www.klepsydra.com/).
 - [MathWorks](https://de.mathworks.com/help/ros/index.html) - ROS Toolbox.

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ The Robot Operating System 2 (ROS 2) is a set of software libraries and tools th
 
 ### Networking
 
-- [Husarnet VPN](https://github.com/husarnet/husarnet)- A P2P, secure network layer dedicated for ROS & ROS 2. ![husarnet](https://img.shields.io/github/stars/husarnet/husarnet.svg)
+- [Husarnet VPN](https://github.com/husarnet/husarnet) - A P2P, secure network layer dedicated for ROS & ROS 2. ![husarnet](https://img.shields.io/github/stars/husarnet/husarnet.svg)
 
 ### Ecosystem
 


### PR DESCRIPTION
Hi! I have added links to a few resources about Husarnet and how to use it with ROS 2 systems:

- link to GitHub repository
- link to project website
- link to a tutorial about connecting ROS 2 nodes over the Internet (featured [on Twitter by Open Robotics](https://twitter.com/OpenRoboticsOrg/status/1417889684844269572))